### PR TITLE
Floors translate3d length to avoid blurry columns

### DIFF
--- a/src/Galahad.js
+++ b/src/Galahad.js
@@ -345,7 +345,7 @@ class Galahad extends React.Component<Props, State> {
                     isSelected={isSelected}
                     style={{
                       width: `${width}px`,
-                      transform: `translate3d(${x}px, 0, 0) scale(${1 + (selected * 0.05)})`,
+                      transform: `translate3d(${Math.floor(x)}px, 0, 0) scale(${1 + (selected * 0.05)})`,
                       boxShadow: `0 ${selected * 16}px ${selected * 24}px 0 rgba(25, 29, 34, ${selected * 0.1})`,
                     }}
                   >


### PR DESCRIPTION
Currently it was possible for the length (tx) passed to translate3d to be a decimal. This caused every n columns to appear blurry.

This would floor the value so it can only be a full number of pixels.